### PR TITLE
docs: remove references to create_service_network

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -14,12 +14,12 @@ You can configure centrally security by using IAM policies for access control, a
 
 When creating a Service Network in the module, the following attributes are expected:
 
-- `name`        = (Optional|string) Name of the Service Network. If `create_service_network` is `true`, this value is required. **This attribute and `identifier` cannot be set at the same time.**
+- `name`        = (Optional|string) Name of the Service Network. This attribute creates a **new** service network using the specified name. **This attribute and `identifier` cannot be set at the same time.**
 - `auth_type`   = (Optional|string) Type of IAM policy to apply in the service network. Allowed values are `NONE` (default) `AWS_IAM`.
 - `auth_policy` = (Optional|any) Auth policy. The policy string in JSON must not contain newlines or blank lines. The auth policy resource will be created only if `auth_type` is set to `AWS_IAM`.
-- `identifier`  = (Optional|string) The ID or ARN of an existing service network. If you are working in multi-AWS account environments, ARN is compulsory. **This attribute and `name` cannot be set at the same time.**
+- `identifier`  = (Optional|string) The ID or ARN of an **existing** service network. If you are working in multi-AWS account environments, ARN is compulsory. **This attribute and `name` cannot be set at the same time.**
 
-Example of creating a service network with `auth_type` equals to `NONE`:
+Example of creating a **new** service network with `auth_type` equals to `NONE`:
 
 ```hcl
 service_network = {
@@ -28,7 +28,7 @@ service_network = {
 }
 ```
 
-Example of creating a service network with `auth_type` equals to `AWS_IAM`:
+Example of creating a **new** service network with `auth_type` equals to `AWS_IAM`:
 
 ```hcl
 service_network = {
@@ -53,7 +53,7 @@ service_network = {
 }
 ```
 
-Example of referencing an existing service network into the module:
+Example of referencing an **existing** service network into the module:
 
 ```hcl
 service_network = {

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@
 variable "service_network" {
   type        = any
   description = <<-EOF
-    Amazon VPC Lattice Service Network information. You can either create a new Service Network or reference a current one (to associate Services or VPCs). The attribute `create_service_network` defines if you want to create or not a service network (`false` by default).
+    Amazon VPC Lattice Service Network information. You can either create a new Service Network or reference a current one (to associate Services or VPCs). Setting the `name` attribute will create a **new** service network, while using the attribute `identifier` will reference an **existing** service network.
     More information about the format of this variable can be found in the "Usage - Service Network" section of the README.
 EOF
 


### PR DESCRIPTION
- updating the docs to remove references to `create_service_network` which is described almost as if it is an input for the module rather than a local variable. I think clarifying and highlighting the role of the `name` and `identifier` attributes on `service_network` will reduce confusion on how to use the module.
- docs: remove create_service_network from service_network description.
- docs: remove create_service_network from header.md.